### PR TITLE
Fix dps client to use device certificate correctly

### DIFF
--- a/Azure.Devices.DeviceClient/ProvisioningDeviceClient.cs
+++ b/Azure.Devices.DeviceClient/ProvisioningDeviceClient.cs
@@ -61,7 +61,7 @@ namespace nanoFramework.Azure.Devices.Provisioning.Client
             string idScope, string registrationId,
             X509Certificate securityProvider, X509Certificate azureCert = null)
         {
-            return new ProvisioningDeviceClient(globalDeviceEndpoint, idScope, registrationId, string.Empty, securityProvider, azureCert);
+            return new ProvisioningDeviceClient(globalDeviceEndpoint, idScope, registrationId, null, securityProvider, azureCert);
         }
 
         private ProvisioningDeviceClient(string globalDeviceEndpoint, string idScope, string registrationId, string securityProvider, X509Certificate deviceCert, X509Certificate azureCert)
@@ -80,7 +80,7 @@ namespace nanoFramework.Azure.Devices.Provisioning.Client
             _mqttc.MqttMsgPublishReceived += ClientMqttMsgReceived;
 
             // Now connect the device
-            string key = deviceCert == null ? Helper.GetSharedAccessSignature(null, securityProvider, $"{idScope}/registrations/{_registrationId}", new TimeSpan(24, 0, 0)) : string.Empty;
+            string key = securityProvider != null ? Helper.GetSharedAccessSignature(null, securityProvider, $"{idScope}/registrations/{_registrationId}", new TimeSpan(24, 0, 0)) : string.Empty;
             _mqttc.Connect(
                 _registrationId,
                 $"{idScope}/registrations/{_registrationId}/api-version=2019-03-31",


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Adjusts the condition to check for null SAK instead of certificate, as that can be null when using device certificate.

## Motivation and Context
- Fixes using DPS with device certificate. After this, everything works correctly together 🎉

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a ESP32-WROOM-32 connecting to Azure.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
