### PR TITLE
Fix Direct Method bug where a formatting error occurs after 10 succes…

### DIFF
--- a/Azure.Devices.DeviceClient/DeviceClient.cs
+++ b/Azure.Devices.DeviceClient/DeviceClient.cs
@@ -394,7 +394,7 @@ namespace nanoFramework.Azure.Devices.Client
                     const string C9PatternMainStyle = "<<Main>$>g__";
                     string method = e.Topic.Substring(DirectMethodTopic.Length);
                     string methodName = method.Substring(0, method.IndexOf('/'));
-                    int rid = Convert.ToInt32(method.Substring(method.IndexOf('=') + 1));
+                    int rid = Convert.ToInt32(method.Substring(method.IndexOf('=') + 1),16);
                     _ioTHubStatus.Status = Status.DirectMethodCalled;
                     _ioTHubStatus.Message = $"{method}/{message}";
                     StatusUpdated?.Invoke(this, new StatusUpdatedEventArgs(_ioTHubStatus));
@@ -411,11 +411,11 @@ namespace nanoFramework.Azure.Devices.Client
                             try
                             {
                                 var res = mt.Invoke(rid, message);
-                                _mqttc.Publish($"$iothub/methods/res/200/?$rid={rid}", Encoding.UTF8.GetBytes(res), MqttQoSLevel.AtLeastOnce, false);
+                                _mqttc.Publish($"$iothub/methods/res/200/?$rid={rid:X}", Encoding.UTF8.GetBytes(res), MqttQoSLevel.AtLeastOnce, false);
                             }
                             catch (Exception ex)
                             {
-                                _mqttc.Publish($"$iothub/methods/res/504/?$rid={rid}", Encoding.UTF8.GetBytes($"{{\"Exception:\":\"{ex}\"}}"), MqttQoSLevel.AtLeastOnce, false);
+                                _mqttc.Publish($"$iothub/methods/res/504/?$rid={rid:X}", Encoding.UTF8.GetBytes($"{{\"Exception:\":\"{ex}\"}}"), MqttQoSLevel.AtLeastOnce, false);
                             }
                         }
                     }


### PR DESCRIPTION
After 10 messages the [rid] in the received message method changes to text [a], not [10]. The conversion instruction then fails when passed a non-numeric value.

## Description
The int-hex conversion has been corrected.
When returning a response, a hex format value for [rid] also needs to be returned. A int- hex text reverse conversion has also been added to correct this.

## Motivation and Context
Correcting a problem where it was impossible to send more than 10 Direct Messages during the same connection session.
- Fixes a non-raised issue 

## How Has This Been Tested?
Tested on own sample project

## Screenshots
Shown below is the exception raised after 10 successfull transmissions:

![image](https://user-images.githubusercontent.com/7484186/148149104-d6547532-7359-4a25-875e-f8fd97dd9a49.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
