### PR TITLE
Make default QoS Level to AtLeastOnce to match default SDK behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,18 @@ void StatusUpdatedEvent(object sender, StatusUpdatedEventArgs e)
 
 Note that those are status change based, so once the connect or disconnect event arrives, they'll be replaced by other events as soon as something else happened like receiving a twin.
 
+### QoS Level
+
+By default, the device SDKs connect to an IoT Hub use QoS 1 for message exchange with the IoT hub. You can change this by setting the `qosLevel` argument of the `DeviceClient` constructor.
+
+Here are existing QoS levels that you can use:
+
+* AtMostOnce: The broker/client will deliver the message once, with no confirmation.
+* AtLeastOnce: The broker/client will deliver the message at least once, with confirmation required.
+* ExactlyOnce: The broker/client will deliver the message exactly once by using a four step handshake.
+
+While it's possible to configure QoS 0 (AtMostOnce) for faster message exchange, you should note that the delivery isn't guaranteed nor acknowledged. For this reason, QoS 0 is often referred as "fire and forget".
+
 ## Azure IoT Device Provisioning Service (DPS) support
 
 This SDK also supports the Azure IoT Device Provisioning Service. Group and individual provisioning scenarios are supported either with a symmetric key either with certificates. To understand the mechanism behind DPS, it is recommended to read the [documentation](https://docs.microsoft.com/azure/iot-dps/).
@@ -336,7 +348,7 @@ if(myDevice.Status != ProvisioningRegistrationStatusType.Assigned)
 }
 
 // You can then create the device
-var device = new DeviceClient(myDevice.AssignedHub, myDevice.DeviceId, SasKey, nanoFramework.M2Mqtt.Messages.MqttQoSLevel.AtMostOnce, azureCA);
+var device = new DeviceClient(myDevice.AssignedHub, myDevice.DeviceId, SasKey, nanoFramework.M2Mqtt.Messages.MqttQoSLevel.AtLeastOnce, azureCA);
 // Open it and continue like for the previous sections
 var res = device.Open();
 if(!res)
@@ -395,7 +407,7 @@ if(myDevice.Status != ProvisioningRegistrationStatusType.Assigned)
 }
 
 // You can then create the device
-var device = new DeviceClient(myDevice.AssignedHub, myDevice.DeviceId, deviceCert, nanoFramework.M2Mqtt.Messages.MqttQoSLevel.AtMostOnce, azureCA);
+var device = new DeviceClient(myDevice.AssignedHub, myDevice.DeviceId, deviceCert, nanoFramework.M2Mqtt.Messages.MqttQoSLevel.AtLeastOnce, azureCA);
 // Open it and continue like for the previous sections
 var res = device.Open();
 if(!res)

--- a/nanoFramework.Azure.Devices.Client/DeviceClient.cs
+++ b/nanoFramework.Azure.Devices.Client/DeviceClient.cs
@@ -65,7 +65,7 @@ namespace nanoFramework.Azure.Devices.Client
         /// <param name="qosLevel">The default quality level delivery for the MQTT messages, default to the lower quality</param>
         /// <param name="azureCert">Azure certificate for the connection to Azure IoT Hub</param>
         /// <param name="modelId">Azure Plug and Play model ID</param>
-        public DeviceClient(string iotHubName, string deviceId, string sasKey, MqttQoSLevel qosLevel = MqttQoSLevel.AtMostOnce, X509Certificate azureCert = null, string modelId = null)
+        public DeviceClient(string iotHubName, string deviceId, string sasKey, MqttQoSLevel qosLevel = MqttQoSLevel.AtLeastOnce, X509Certificate azureCert = null, string modelId = null)
         {
             _isCertificate = false;
             _clientCert = null;


### PR DESCRIPTION

## Description
Following the default Azure Device SDK behavior, the default MQTT QoS Level is 1 (AtLeastOnce). This PR is the change i purpose to match this defaults: 

* default constructor argument value to QoS 1
* Add some notes on the README to explain that

## Motivation and Context
I was frustating while starting the SDK on my ESP32 when I didn't received the messages on the hub, I was wondering that the works as the standard Device SDK.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
>

## Screenshots<!-- (if appropriate): -->

The Azure Documentation: 
[https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#using-the-device-sdks](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#using-the-device-sdks)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
