### PR TITLE
Fix of the wrong spelled event name TwinUpated

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Reporting Plug & Play properties is supported. He is a comprehensive example and
 ```csharp
 const string TargetTemerature = "targetTemperature";
 DeviceClient azureIoT = new DeviceClient(Secrets.IotHub, Secrets.DeviceName, Secrets.SasKey, azureCert: new X509Certificate(Resource.GetBytes(Resource.BinaryResources.AzureRoot)), modelId: "dtmi:com:example:Thermostat;1");
-azureIoT.TwinUpated += AzureTwinUpdated;
+azureIoT.TwinUpdated += AzureTwinUpdated;
 azureIoT.Open();
 
 void AzureTwinUpdated(object sender, TwinUpdateEventArgs e)
@@ -192,11 +192,11 @@ Note: the function will return false if the twin reception confirmation is not c
 You can also register for any twin update:
 
 ```csharp
-azureIoT.TwinUpated += TwinUpdatedEvent;
+azureIoT.TwinUpdated += TwinUpdatedEvent;
 
 void TwinUpdatedEvent(object sender, TwinUpdateEventArgs e)
 {
-    Debug.WriteLine($"Twin update received:  {e.Twin.Count}");
+    Debug.WriteLine($"Twin update received: {e.Twin.Count}");
 }
 ```
 

--- a/nanoFramework.Azure.Devices.Client/DeviceClient.cs
+++ b/nanoFramework.Azure.Devices.Client/DeviceClient.cs
@@ -44,7 +44,7 @@ namespace nanoFramework.Azure.Devices.Client
         /// <summary>
         /// Device twin updated event.
         /// </summary>
-        public event TwinUpdated TwinUpated;
+        public event TwinUpdated TwinUpdated;
 
         /// <summary>
         /// Status change event.
@@ -67,7 +67,6 @@ namespace nanoFramework.Azure.Devices.Client
         /// <param name="azureCert">Azure certificate for the connection to Azure IoT Hub.</param>
         /// <param name="modelId">Azure Plug and Play model ID.</param>
         public DeviceClient(string iotHubName, string deviceId, string moduleId, string sasKey, MqttQoSLevel qosLevel = MqttQoSLevel.AtLeastOnce, X509Certificate azureCert = null, string modelId = null)
-
         {
             _clientCert = null;
             _iotHubName = iotHubName;
@@ -416,7 +415,7 @@ namespace nanoFramework.Azure.Devices.Client
                     }
                     else if (e.Topic.StartsWith("$iothub/twin/PATCH/properties/desired/"))
                     {
-                        TwinUpated?.Invoke(this, new TwinUpdateEventArgs(new TwinCollection(message)));
+                        TwinUpdated?.Invoke(this, new TwinUpdateEventArgs(new TwinCollection(message)));
                         _ioTHubStatus.Status = Status.TwinUpdateReceived;
                         _ioTHubStatus.Message = string.Empty;
                         StatusUpdated?.Invoke(this, new StatusUpdatedEventArgs(_ioTHubStatus));


### PR DESCRIPTION
## Description
In nanoFramework.Azure.Devices.Client.DeviceClient the event TwinUpated is spelled wrong.

## Motivation and Context
- Fixes nanoFramework/Home#1047

## How Has This Been Tested?
Project Builds.

## Types of changes
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [X] My code follows the code style of this project (only if there are changes in source code).
- [X] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
